### PR TITLE
Update Shouldly to latest nuget package version.

### DIFF
--- a/src/JustBehave.Tests/AsyncBehaviourTests/WhenTestingForExceptions.cs
+++ b/src/JustBehave.Tests/AsyncBehaviourTests/WhenTestingForExceptions.cs
@@ -20,7 +20,7 @@ namespace JustBehave.Tests.AsyncBehaviourTests
         [Then, Test]
         public void ExceptionShouldBeOfExpectedType()
         {
-            ThrownException.ShouldBeTypeOf<InvalidOperationException>();
+            ThrownException.ShouldBeAssignableTo<InvalidOperationException>();
         }
     }
 

--- a/src/JustBehave.Tests/Examples/WhenTestingForExceptions.cs
+++ b/src/JustBehave.Tests/Examples/WhenTestingForExceptions.cs
@@ -18,7 +18,7 @@ namespace JustBehave.Tests.Examples
         [Then]
         public void ExceptionShouldBeOfExpectedType()
         {
-            ThrownException.ShouldBeTypeOf<InvalidOperationException>();
+            ThrownException.ShouldBeAssignableTo<InvalidOperationException>();
         }
     }
 

--- a/src/JustBehave.Tests/Examples/WhenTestingForExceptionsFromConstructors.cs
+++ b/src/JustBehave.Tests/Examples/WhenTestingForExceptionsFromConstructors.cs
@@ -20,7 +20,7 @@ namespace JustBehave.Tests.Examples
         [Then]
         public void ShouldSeeException()
         {
-            ThrownException.ShouldBeTypeOf<NotSupportedException>();
+            ThrownException.ShouldBeAssignableTo<NotSupportedException>();
         }
     }
 

--- a/src/JustBehave.Tests/JustBehave.Tests.csproj
+++ b/src/JustBehave.Tests/JustBehave.Tests.csproj
@@ -54,8 +54,9 @@
     <Reference Include="Rhino.Mocks">
       <HintPath>..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>
     </Reference>
-    <Reference Include="Shouldly">
-      <HintPath>..\packages\Shouldly.1.1.1.1\lib\35\Shouldly.dll</HintPath>
+    <Reference Include="Shouldly, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
+      <HintPath>..\packages\Shouldly.2.6.0\lib\net40\Shouldly.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">

--- a/src/JustBehave.Tests/packages.config
+++ b/src/JustBehave.Tests/packages.config
@@ -5,6 +5,6 @@
   <package id="NLog" version="4.1.2" targetFramework="net451" />
   <package id="NUnit" version="2.6.4" targetFramework="net451" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net40" />
-  <package id="Shouldly" version="1.1.1.1" targetFramework="net40" />
+  <package id="Shouldly" version="2.6.0" targetFramework="net451" />
   <package id="xunit" version="1.9.2" targetFramework="net40" />
 </packages>

--- a/src/JustBehave/JustBehave.csproj
+++ b/src/JustBehave/JustBehave.csproj
@@ -47,9 +47,9 @@
       <HintPath>..\packages\AutoFixture.3.34.2\lib\net40\Ploeh.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Shouldly, Version=1.1.1.1, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Shouldly.1.1.1.1\lib\35\Shouldly.dll</HintPath>
+    <Reference Include="Shouldly, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
+      <HintPath>..\packages\Shouldly.2.6.0\lib\net40\Shouldly.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/JustBehave/packages.config
+++ b/src/JustBehave/packages.config
@@ -3,5 +3,5 @@
   <package id="AutoFixture" version="3.34.2" targetFramework="net451" />
   <package id="NLog" version="4.1.2" targetFramework="net451" />
   <package id="NUnit" version="2.6.4" targetFramework="net451" />
-  <package id="Shouldly" version="1.1.1.1" targetFramework="net40" />
+  <package id="Shouldly" version="2.6.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Update Shouldly to latest nuget package version.
One breaking change in Shouldly:
In 3 tests, change `ShouldBeTypeOf` to `ShouldBeAssignableTo`