### PR TITLE
updates for issue 16

### DIFF
--- a/src/JustBehave.Tests/Examples/WhenTestingSomethingWithDependencies.cs
+++ b/src/JustBehave.Tests/Examples/WhenTestingSomethingWithDependencies.cs
@@ -24,7 +24,7 @@ namespace JustBehave.Tests.Examples
             _speech = SystemUnderTest.SomethingElse.SayHello();
         }
 
-        protected override void CustomizeAutoFixture(Fixture fixture)
+        protected override void CustomizeAutoFixture(IFixture fixture)
         {
             fixture.Customize(new AutoRhinoMockCustomization());
         }

--- a/src/JustBehave.Tests/JustBehave.Tests.csproj
+++ b/src/JustBehave.Tests/JustBehave.Tests.csproj
@@ -36,19 +36,19 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.1.2\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.2.0\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture, Version=3.34.2.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.3.34.2\lib\net40\Ploeh.AutoFixture.dll</HintPath>
+    <Reference Include="Ploeh.AutoFixture, Version=3.36.9.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.3.36.9\lib\net40\Ploeh.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture.AutoRhinoMock, Version=3.34.2.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.AutoRhinoMocks.3.34.2\lib\net40\Ploeh.AutoFixture.AutoRhinoMock.dll</HintPath>
+    <Reference Include="Ploeh.AutoFixture.AutoRhinoMock, Version=3.36.9.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.AutoRhinoMocks.3.36.9\lib\net40\Ploeh.AutoFixture.AutoRhinoMock.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Rhino.Mocks, Version=3.6.0.0, Culture=neutral, PublicKeyToken=0b3305902db7183f, processorArchitecture=MSIL">

--- a/src/JustBehave.Tests/JustBehave.Tests.csproj
+++ b/src/JustBehave.Tests/JustBehave.Tests.csproj
@@ -52,7 +52,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Rhino.Mocks, Version=3.6.0.0, Culture=neutral, PublicKeyToken=0b3305902db7183f, processorArchitecture=MSIL">
-      <HintPath>..\packages\RhinoMocks.3.6\lib\Rhino.Mocks.dll</HintPath>
+      <HintPath>..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Shouldly, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">

--- a/src/JustBehave.Tests/app.config
+++ b/src/JustBehave.Tests/app.config
@@ -1,14 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Ploeh.AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.34.2.0" newVersion="3.34.2.0"/>
+        <assemblyIdentity name="Ploeh.AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.36.9.0" newVersion="3.36.9.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
   </startup>
 </configuration>

--- a/src/JustBehave.Tests/packages.config
+++ b/src/JustBehave.Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="AutoFixture.AutoRhinoMocks" version="3.36.9" targetFramework="net452" />
   <package id="NLog" version="4.2.0" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
-  <package id="RhinoMocks" version="3.6" targetFramework="net452" />
+  <package id="RhinoMocks" version="3.6.1" targetFramework="net452" />
   <package id="Shouldly" version="2.6.0" targetFramework="net452" />
   <package id="xunit" version="1.9.2" targetFramework="net40" />
 </packages>

--- a/src/JustBehave.Tests/packages.config
+++ b/src/JustBehave.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="3.34.2" targetFramework="net452" />
-  <package id="AutoFixture.AutoRhinoMocks" version="3.34.2" targetFramework="net452" />
-  <package id="NLog" version="4.1.2" targetFramework="net452" />
+  <package id="AutoFixture" version="3.36.9" targetFramework="net452" />
+  <package id="AutoFixture.AutoRhinoMocks" version="3.36.9" targetFramework="net452" />
+  <package id="NLog" version="4.2.0" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
   <package id="RhinoMocks" version="3.6" targetFramework="net452" />
   <package id="Shouldly" version="2.6.0" targetFramework="net452" />

--- a/src/JustBehave/AsyncBehaviourTestBase.cs
+++ b/src/JustBehave/AsyncBehaviourTestBase.cs
@@ -26,7 +26,7 @@ namespace JustBehave
         // ReSharper restore DoNotCallOverridableMethodsInConstructor
 
 // ReSharper disable MemberCanBePrivate.Global
-        protected Fixture Fixture { get; private set; }
+        protected IFixture Fixture { get; private set; }
         protected Logger Log { get; private set; }
         protected TargetWithLayout LoggingTarget { get; private set; }
 // ReSharper restore MemberCanBePrivate.Global
@@ -50,7 +50,7 @@ namespace JustBehave
             return Fixture.Create<TSystemUnderTest>();
         }
 
-        protected virtual void CustomizeAutoFixture(Fixture fixture) { }
+        protected virtual void CustomizeAutoFixture(IFixture fixture) { }
 
         protected async Task Execute()
         {

--- a/src/JustBehave/BehaviourTestBase.cs
+++ b/src/JustBehave/BehaviourTestBase.cs
@@ -24,7 +24,7 @@ namespace JustBehave
         }
         // ReSharper restore DoNotCallOverridableMethodsInConstructor
 
-        protected Fixture Fixture { get; private set; }
+        protected IFixture Fixture { get; private set; }
         protected Logger Log { get; private set; }
         protected TargetWithLayout LoggingTarget { get; private set; }
         protected TSystemUnderTest SystemUnderTest { get; private set; }
@@ -47,7 +47,7 @@ namespace JustBehave
             return Fixture.Create<TSystemUnderTest>();
         }
 
-        protected virtual void CustomizeAutoFixture(Fixture fixture) {}
+        protected virtual void CustomizeAutoFixture(IFixture fixture) {}
 
         protected void Execute()
         {

--- a/src/JustBehave/JustBehave.csproj
+++ b/src/JustBehave/JustBehave.csproj
@@ -36,15 +36,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.1.2\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.2.0\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture, Version=3.34.2.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.3.34.2\lib\net40\Ploeh.AutoFixture.dll</HintPath>
+    <Reference Include="Ploeh.AutoFixture, Version=3.36.9.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.3.36.9\lib\net40\Ploeh.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Shouldly, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">

--- a/src/JustBehave/packages.config
+++ b/src/JustBehave/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="3.34.2" targetFramework="net452" />
-  <package id="NLog" version="4.1.2" targetFramework="net452" />
+  <package id="AutoFixture" version="3.36.9" targetFramework="net452" />
+  <package id="NLog" version="4.2.0" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
   <package id="Shouldly" version="2.6.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
fixes for https://github.com/justeat/JustBehave/issues/16
- update packages to latest: NLog, AutoFixture, RhinoMocks
- use `IFixture` interface from AutoFixture, not `Fixture`, the impl class of that.