### PR TITLE
Update NUnit to version 3.0.1

### DIFF
--- a/src/JustBehave.Tests/JustBehave.Tests.csproj
+++ b/src/JustBehave.Tests/JustBehave.Tests.csproj
@@ -39,8 +39,8 @@
       <HintPath>..\packages\NLog.4.2.0\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Ploeh.AutoFixture, Version=3.36.9.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">

--- a/src/JustBehave.Tests/packages.config
+++ b/src/JustBehave.Tests/packages.config
@@ -3,7 +3,7 @@
   <package id="AutoFixture" version="3.36.9" targetFramework="net452" />
   <package id="AutoFixture.AutoRhinoMocks" version="3.36.9" targetFramework="net452" />
   <package id="NLog" version="4.2.0" targetFramework="net452" />
-  <package id="NUnit" version="2.6.4" targetFramework="net452" />
+  <package id="NUnit" version="3.0.1" targetFramework="net452" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net452" />
   <package id="Shouldly" version="2.6.0" targetFramework="net452" />
   <package id="xunit" version="1.9.2" targetFramework="net40" />

--- a/src/JustBehave/AsyncBehaviourTest.cs
+++ b/src/JustBehave/AsyncBehaviourTest.cs
@@ -5,13 +5,13 @@ namespace JustBehave
     [TestFixture]
     public abstract class AsyncBehaviourTest<TSystemUnderTest> : AsyncBehaviourTestBase<TSystemUnderTest>
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void Go()
         {
             AsyncExtensions.RunSynchronously(Execute);
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public new virtual void PostAssertTeardown() { }
     }
 }

--- a/src/JustBehave/BehaviourTest.cs
+++ b/src/JustBehave/BehaviourTest.cs
@@ -9,13 +9,13 @@ namespace JustBehave
     [TestFixture]
     public abstract class BehaviourTest<TSystemUnderTest> : BehaviourTestBase<TSystemUnderTest>
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void Go()
         {
             Execute();
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public new virtual void PostAssertTeardown() {}
     }
 }

--- a/src/JustBehave/JustBehave.csproj
+++ b/src/JustBehave/JustBehave.csproj
@@ -39,8 +39,8 @@
       <HintPath>..\packages\NLog.4.2.0\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Ploeh.AutoFixture, Version=3.36.9.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">

--- a/src/JustBehave/packages.config
+++ b/src/JustBehave/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="AutoFixture" version="3.36.9" targetFramework="net452" />
   <package id="NLog" version="4.2.0" targetFramework="net452" />
-  <package id="NUnit" version="2.6.4" targetFramework="net452" />
+  <package id="NUnit" version="3.0.1" targetFramework="net452" />
   <package id="Shouldly" version="2.6.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
We want this for JustSaying, it is upstream of JustSaying and prevents JustSaying from easily applying this same update to NUnit