### PR TITLE
Prepare 2.0

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -30,6 +30,6 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(NCrunch)' == '' and '$(SourceLinkEnabled)' != 'false'">
-    <PackageReference Include="SourceLink.Embed.AllSourceFiles" Version="2.4.0" PrivateAssets="All" />
+    <PackageReference Include="SourceLink.Embed.AllSourceFiles" Version="2.8.3" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -18,7 +18,7 @@
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">0</BuildNumber>
 
     <!-- Remove for release -->
-    <PrereleaseLabel>-beta</PrereleaseLabel>
+    <!-- <PrereleaseLabel>-beta</PrereleaseLabel> -->
 
     <BuildSuffix Condition=" '$(PrereleaseLabel)' != '' ">$(PrereleaseLabel)-$(BuildNumber)</BuildSuffix>
     <BuildSuffix Condition=" '$(BuildSuffix)' == '' "></BuildSuffix>

--- a/src/JustBehave.Tests/Examples/WhenTestingSomethingWithDependencies.cs
+++ b/src/JustBehave.Tests/Examples/WhenTestingSomethingWithDependencies.cs
@@ -27,7 +27,7 @@ namespace JustBehave.Tests.Examples
 
         protected override void CustomizeAutoFixture(IFixture fixture)
         {
-            fixture.Customize(new AutoConfiguredNSubstituteCustomization());
+            fixture.Customize(new AutoNSubstituteCustomization{ ConfigureMembers = true });
         }
 
         [Fact]

--- a/src/JustBehave.Tests/JustBehave.Tests.csproj
+++ b/src/JustBehave.Tests/JustBehave.Tests.csproj
@@ -5,15 +5,15 @@
     <NoWarn>$(NoWarn);NU1603</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.0.0-rc1" />
-    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.0.0-rc1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="NLog" Version="4.5.0-rc02" />
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="Shouldly" Version="3.0.0-beta0003" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="AutoFixture" Version="4.5.0" />
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="NLog" Version="4.5.8" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Shouldly" Version="3.0.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\JustBehave\JustBehave.csproj" />

--- a/src/JustBehave/JustBehave.csproj
+++ b/src/JustBehave/JustBehave.csproj
@@ -3,8 +3,8 @@
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.5.0-rc02" />
-    <PackageReference Include="AutoFixture" Version="4.0.0-rc1" />
-    <PackageReference Include="Shouldly" Version="3.0.0-beta0003" />
+    <PackageReference Include="NLog" Version="4.5.8" />
+    <PackageReference Include="AutoFixture" Version="4.5.0" />
+    <PackageReference Include="Shouldly" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/src/JustBehave/JustBehave.csproj
+++ b/src/JustBehave/JustBehave.csproj
@@ -4,7 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NLog" Version="4.5.0-rc02" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
     <PackageReference Include="AutoFixture" Version="4.0.0-rc1" />
     <PackageReference Include="Shouldly" Version="3.0.0-beta0003" />
   </ItemGroup>


### PR DESCRIPTION
Get rid of beta package references, and make it so that the main package doesn't reference NUnit (which was the whole point of the previous refactor) as it's now split out into JustBehave.NUnit.

After making a non-beta 2.0 release, it might be work updating the top of the README with a statement about it's current support strategy and alternative approaches/libraries.